### PR TITLE
Find and replace now using a function as accepted replacer. Resolves #6

### DIFF
--- a/src/customErrors.ts
+++ b/src/customErrors.ts
@@ -1,0 +1,76 @@
+/**
+ * 
+ *
+ */
+class BaseException extends Error {
+  readonly _e = true;
+  readonly key: string;
+
+  constructor(msg: string, key: string) {
+    super(msg);
+    this.key = key;
+  }
+}
+
+export class Exception_OutOfBounds extends BaseException {
+  static defaultMessage = "Out of bounds";
+  static key = "out_of_bounds";
+
+  constructor(msg = Exception_OutOfBounds.defaultMessage) {
+    super(msg, Exception_OutOfBounds.key);
+  }
+}
+
+export class Exception_FindReplaceIllegalAction extends BaseException {
+  static defaultMessage =
+    "Action not allowed. Both addIfNotFound and replaceVal as a function isn't allowed.";
+  static key = "find_replace_illegal_action";
+
+  constructor(msg = Exception_FindReplaceIllegalAction.defaultMessage) {
+    super(msg, Exception_FindReplaceIllegalAction.key);
+  }
+}
+
+/**
+ * This is ~~black magic~~ a helper type fow declaring static variables to be present on the type of a static input.
+ *
+ * Say you want to put in the class declaration and not an instance of the class, this interface wraps this
+ * and provides a required typed constructor.
+ *
+ * Example:
+ * ```typescript
+ *
+ * const myMethod = (input: ClassBuilder) {
+ *    console.log(input.key)
+ * }
+ *
+ * myMethod(BaseError) //gives error `Property 'key' is missing in type 'typeof BaseError' but required in type 'ClassBuilder<BaseError>'`
+ *
+ * myMethod(OutOfBounds) //OK
+ * ```
+ */
+interface ClassBuilder<T = BaseException> {
+  new (msg: string): T;
+  defaultMessage: string;
+  key: string;
+}
+
+/**
+ * Assert and type guard input error to be one of the custom Error types.
+ * The asserted type is derived from the second parameter.
+ *
+ * @param err : instance of the error to assert and type guard
+ * @param errorClass : Static class input of a custom Error
+ */
+export function assertErrorType<T extends BaseException>(
+  err: BaseException,
+  errorClass: ClassBuilder<T>
+): asserts err is T {
+  if (err._e !== true) {
+    throw Error("Not a custom Error");
+  }
+
+  if (err.key !== errorClass.key) {
+    throw Error("Not the same error type");
+  }
+}

--- a/src/customErrors.ts
+++ b/src/customErrors.ts
@@ -1,6 +1,5 @@
 /**
- * 
- *
+ * This is a base class used only to wrap a few required attributes away from each custom exception
  */
 class BaseException extends Error {
   readonly _e = true;
@@ -59,8 +58,16 @@ interface ClassBuilder<T = BaseException> {
  * Assert and type guard input error to be one of the custom Error types.
  * The asserted type is derived from the second parameter.
  *
- * @param err : instance of the error to assert and type guard
- * @param errorClass : Static class input of a custom Error
+ * Example:
+ * ```typescript
+ * try { ... } catch (err) {
+ *   assertErrorType(err, Exception_FindReplaceIllegalAction);
+ *   // err is now typed as Exception_FindReplaceIllegalAction
+ * }
+ * ```
+ *
+ * @param err instance of the error to assert and type guard
+ * @param errorClass Static class input of a custom Error
  */
 export function assertErrorType<T extends BaseException>(
   err: BaseException,

--- a/src/customErrors.ts
+++ b/src/customErrors.ts
@@ -31,7 +31,7 @@ export class Exception_FindReplaceIllegalAction extends BaseException {
 }
 
 /**
- * This is ~~black magic~~ a helper type fow declaring static variables to be present on the type of a static input.
+ * This is ~~black magic~~ a helper type for declaring static variables to be present on the type of a static input.
  *
  * Say you want to put in the class declaration and not an instance of the class, this interface wraps this
  * and provides a required typed constructor.
@@ -39,13 +39,13 @@ export class Exception_FindReplaceIllegalAction extends BaseException {
  * Example:
  * ```typescript
  *
- * const myMethod = (input: ClassBuilder) {
+ * const myMethod = (input: ClassBuilder) => {
  *    console.log(input.key)
  * }
  *
- * myMethod(BaseError) //gives error `Property 'key' is missing in type 'typeof BaseError' but required in type 'ClassBuilder<BaseError>'`
+ * myMethod(BaseError) // Gives type error `Property 'key' is missing in type 'typeof BaseError' but required in type 'ClassBuilder<BaseError>'`
  *
- * myMethod(OutOfBounds) //OK
+ * myMethod(OutOfBounds) // OK
  * ```
  */
 interface ClassBuilder<T = BaseException> {
@@ -80,4 +80,26 @@ export function assertErrorType<T extends BaseException>(
   if (err.key !== errorClass.key) {
     throw Error("Not the same error type");
   }
+}
+
+/**
+ * Custom type guard of the exception classes.
+ *
+ * Example:
+ * ```typescript
+* try { ... } catch (err) {
+ *   if (isErrorType(err, Exception_FindReplaceIllegalAction)) {
+ *      // err is now typed as Exception_FindReplaceIllegalAction
+ *   }
+ * }
+ * ```
+ *
+ * @param err instance of the error to type guard
+ * @param errorClass Static class input of a custom Error
+ */
+export function isErrorType<T extends BaseException>(
+  err: BaseException,
+  errorClass: ClassBuilder<T>
+): err is T {
+  return err._e === true && err.key === errorClass.key;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { Exception_FindReplaceIllegalAction, Exception_OutOfBounds } from "./customErrors";
+import { isFunction } from "./typeGuards";
 import "./types";
 /// <reference path="types.d.ts" />
 
@@ -41,9 +43,9 @@ Array.prototype.average = function (
   round = null,
   thisArg = this
 ) {
-  if (thisArg.length <= 0) throw Error("Out of bounds");
+  if (thisArg.length <= 0) throw new Exception_OutOfBounds();
   if (round !== null) {
-    if (round < 0) throw Error("Out of bounds");
+    if (round < 0) throw new Exception_OutOfBounds();
     const roundInTens = 10 ** round;
     return (
       Math.round((thisArg.sum(func, thisArg) / thisArg.length) * roundInTens) /
@@ -90,7 +92,7 @@ Array.prototype.chunkByCount = function (
   forceFairness = false,
   thisArg = this
 ) {
-  if (chunkCount <= 0) throw Error("Out of bounds");
+  if (chunkCount <= 0) throw new Exception_OutOfBounds();
 
   const result: any[][] = [];
   for (let i = chunkCount; i > 0; i--) {
@@ -112,7 +114,7 @@ Array.prototype.chunkBySize = function (
   treatChunkSizeAsMax = false,
   thisArg = this
 ) {
-  if (chunkSize <= 0) throw Error("Out of bounds");
+  if (chunkSize <= 0) throw new Exception_OutOfBounds();
   const result: any[][] = [];
 
   if (forceFairness) {
@@ -155,9 +157,9 @@ Array.prototype.chunkBySize = function (
   return result;
 };
 
-Array.prototype.findAndReplace = function (
-  predicate,
-  replaceVal,
+Array.prototype.findAndReplace = function <T extends Object>(
+  predicate: (value: T, index: number, obj: T[]) => boolean,
+  replaceVal: T | ((t?: T) => T),
   addIfNotFound = false,
   thisArg = this
 ) {
@@ -166,11 +168,22 @@ Array.prototype.findAndReplace = function (
     if (!addIfNotFound) {
       return null;
     }
-    thisArg.push(replaceVal);
+
+    if (isFunction(replaceVal)) {
+      throw new Exception_FindReplaceIllegalAction();
+    } else {
+      thisArg.push(replaceVal);
+    }
     return null;
   }
   const oldItem = thisArg[oldIndex];
-  thisArg[oldIndex] = replaceVal;
+
+  if (isFunction(replaceVal)) {
+    thisArg[oldIndex] = replaceVal(thisArg[oldIndex]);
+  } else {
+    thisArg[oldIndex] = replaceVal;
+  }
+
   return oldItem;
 };
 

--- a/src/typeGuards.ts
+++ b/src/typeGuards.ts
@@ -1,0 +1,3 @@
+export function isFunction<T>(val: T | ((t?: T) => T)): val is (t?: T) => T {
+  return typeof val === "function";
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,7 +189,7 @@ interface Array<T> {
    */
   findAndReplace(
     predicate: (value: T, index: number, obj: T[]) => boolean,
-    replaceVal: T,
+    replaceVal: T | ((t?: T) => T),
     addIfNotFound?: boolean,
     thisArg?: any[]
   ): T;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,34 +1,12 @@
 import "../src/index";
-import { expect } from "chai";
+import { assert, expect } from "chai";
 import { describe } from "mocha";
 
-type Score = {
-  id: string;
-  index: number;
-  isActive: boolean;
-  balance: string;
-  picture: string;
-  age: number;
-  name: {
-    first: string;
-    last: string;
-  };
-  email: string;
-  phone: string;
-  registered: string;
-  latitude: string; //maybe number
-  longitude: string; //maybe number
-  tags: string[];
-  friends: {
-    id: number;
-    name: string;
-  }[];
-  greeting: string;
-  favoriteFruit: string;
-};
-
-import * as data from "./test.data.json";
-const myArr: Score[] = data;
+import {
+  assertErrorType,
+  Exception_FindReplaceIllegalAction
+} from "../src/customErrors";
+import { myArr, Score } from "./testData";
 
 const ASSERTIONS = {
   ARRAY_LENGTH: 17,
@@ -298,5 +276,48 @@ describe("findAndReplace", () => {
     expect(myArr.find(x => x.index === 500).id).equal("adasdasd");
     expect(oldScore).equal(null);
     expect(myArr.length).equal(ASSERTIONS.ARRAY_LENGTH + 1);
+  });
+
+  it("findReplace functions", () => {
+    myArr.findAndReplace(
+      x => x.index === 500,
+      x => {
+        x.id = "123456";
+        return x;
+      }
+    );
+
+    expect(myArr.find(x => x.index === 500).id).equal("123456");
+  });
+
+  it("findReplace functions for not found", () => {
+    myArr.findAndReplace(
+      x => x.index === 50000,
+      x => {
+        x.id = "123456";
+        return x;
+      }
+    );
+
+    expect(myArr.find(x => x.index === 50000)).equal(undefined);
+  });
+
+  it("illegal action findReplace functions for not found and insert", () => {
+    try {
+      myArr.findAndReplace(
+        x => x.index === 50000,
+        x => x,
+        true
+      );
+
+      assert(
+        false,
+        "This function didn't throw error like it was expected to."
+      );
+    } catch (err) {
+      assertErrorType(err, Exception_FindReplaceIllegalAction);
+
+      expect(err.constructor.name).equal("Exception_FindReplaceIllegalAction");
+    }
   });
 });

--- a/tests/testData.ts
+++ b/tests/testData.ts
@@ -1,0 +1,27 @@
+export type Score = {
+  id: string;
+  index: number;
+  isActive: boolean;
+  balance: string;
+  picture: string;
+  age: number;
+  name: {
+    first: string;
+    last: string;
+  };
+  email: string;
+  phone: string;
+  registered: string;
+  latitude: string; //maybe number
+  longitude: string; //maybe number
+  tags: string[];
+  friends: {
+    id: number;
+    name: string;
+  }[];
+  greeting: string;
+  favoriteFruit: string;
+};
+
+import * as data from "./test.data.json";
+export const myArr: Score[] = data;


### PR DESCRIPTION
Instead of having to fill in an object, the user can now provide a method that mutates the found object.


Example:
```typescript
myArr.findAndReplace(
  x => x.id=== 5, 
  x => {
    x.name = "Charles";
    return x;
  }
);
```


Other enhancements include an array of typed Exceptions in place of throwing Errors.
